### PR TITLE
Remove deprecated IP lists from update_tables.py and urltable_inbound

### DIFF
--- a/tables/inbound/urltable_inbound
+++ b/tables/inbound/urltable_inbound
@@ -20,10 +20,7 @@ https://raw.githubusercontent.com/borestad/firehol-mirror/main/vxvault.ipset
 https://raw.githubusercontent.com/borestad/firehol-mirror/main/xroxy.ipset
 https://raw.githubusercontent.com/borestad/firehol-mirror/main/iblocklist_ciarmy_malicious.netset
 https://raw.githubusercontent.com/borestad/blocklist-abuseipdb/main/abuseipdb-s100-14d.ipv4
-https://www.spamhaus.org/drop/edrop.txt
 https://www.spamhaus.org/drop/drop.txt
-https://sslbl.abuse.ch/blacklist/sslipblacklist.txt
-https://feodotracker.abuse.ch/downloads/ipblocklist_recommended.txt
 https://cinsscore.com/list/ci-badguys.txt
 https://raw.githubusercontent.com/bitwire-it/ipsum-clean/main/ipsum.txt
 https://raw.githubusercontent.com/bitwire-it/ip_list_fetch/refs/heads/main/blacklist.txt
@@ -42,7 +39,6 @@ https://raw.githubusercontent.com/ShadowWhisperer/IPs/master/Malware/Hosting
 https://raw.githubusercontent.com/ShadowWhisperer/IPs/master/BruteForce/Medium
 https://raw.githubusercontent.com/ShadowWhisperer/IPs/master/BruteForce/High
 https://raw.githubusercontent.com/ShadowWhisperer/IPs/master/BruteForce/Extreme
-https://osint.digitalside.it/Threat-Intel/lists/latestips.txt
 https://raw.githubusercontent.com/romainmarcoux/malicious-ip/main/full-aa.txt
 https://raw.githubusercontent.com/romainmarcoux/malicious-ip/main/full-ab.txt
 https://raw.githubusercontent.com/romainmarcoux/malicious-ip/main/full-ac.txt

--- a/update_tables.py
+++ b/update_tables.py
@@ -292,13 +292,9 @@ This blocklist is aggregated from the following reputable sources:
 - [darklist.de](https://www.darklist.de/raw.php)
 - [dan.me.uk Tor List](https://www.dan.me.uk/torlist/)
 - [Emerging Threats](http://rules.emergingthreats.net/blockrules/compromised-ips.txt)
-- [Spamhaus EDROP](https://www.spamhaus.org/drop/edrop.txt)
 - [Spamhaus DROP](https://www.spamhaus.org/drop/drop.txt)
-- [Abuse.ch SSLBL](https://sslbl.abuse.ch/blacklist/sslipblacklist.txt)
-- [Abuse.ch Feodo](https://feodotracker.abuse.ch/downloads/ipblocklist_recommended.txt)
 - [CINSscore](https://cinsscore.com/list/ci-badguys.txt)
 - [Talos Intelligence](https://talosintelligence.com/documents/ip-blacklist)
-- [DigitalSide Threat-Intel](https://osint.digitalside.it/Threat-Intel/lists/latestips.txt)
 - [CriticalPathSecurity](https://github.com/CriticalPathSecurity/Public-Intelligence-Feeds)
 - [C2 Tracker](https://github.com/montysecurity/C2-Tracker)
 


### PR DESCRIPTION
I noticed that a few of the IP lists that are used in the inbound URL table are no longer being maintained, so I removed them from `urltable_inbound` and from `update_readme` in `update_tables.py`.

- `https://www.spamhaus.org/drop/edrop.txt` has been merged into drop.txt
- `https://sslbl.abuse.ch/blacklist/sslipblacklist.txt` deprecated 2025-01-02
- `https://feodotracker.abuse.ch/downloads/ipblocklist_recommended.txt` last updated 2025-07-05, no IPs in the list
- `https://osint.digitalside.it/Threat-Intel/lists/latestips.txt` website seems to have been taken down, GitHub repo has not been updated in 11 months https://github.com/davidonzo/Threat-Intel. https://github.com/davidonzo/Threat-Intel/issues/51

I ran update_tables.py locally and it worked fine with these removed.