### PR TITLE
Add exception for UptimeRobot

### DIFF
--- a/tables/inbound/urlexclusion_inbound
+++ b/tables/inbound/urlexclusion_inbound
@@ -1,2 +1,3 @@
 https://public-dns.info/nameservers.txt
 https://raw.githubusercontent.com/bitwire-it/ip_list_fetch/refs/heads/main/dns.txt
+https://cdn.uptimerobot.com/api/IPv4andIPv6.txt


### PR DESCRIPTION
Add exception for UptimeRobot uptime monitoring service, see https://uptimerobot.com/help/locations/ 
Currently, the following legitimate monitoring IPs are listed in inbound.txt:

`
grep -wFf IPv4andIPv6.txt inbound.txt 
3.12.251.153
3.20.63.178
3.77.67.4
3.133.226.214
3.149.57.90
5.161.75.7
5.161.177.47
5.161.194.92
49.13.164.148
52.15.147.27
52.87.72.16
78.46.215.1
88.99.80.227
157.90.155.240
167.235.143.113
178.156.181.172
216.144.248.29
`