### PR TITLE
Exclude GitHub ranges from inbound list too (fixes #35)

### DIFF
--- a/tables/inbound/urlexclusion_inbound
+++ b/tables/inbound/urlexclusion_inbound
@@ -1,2 +1,3 @@
 https://public-dns.info/nameservers.txt
 https://raw.githubusercontent.com/bitwire-it/ip_list_fetch/refs/heads/main/dns.txt
+https://raw.githubusercontent.com/bitwire-it/Github-IP/refs/heads/main/github_ip_list.txt


### PR DESCRIPTION
## Problem (#35)

GitHub's published ranges (`140.82.112.0/20`, `185.199.108.0/22`, …) were appearing in `inbound.txt` as individual host IPs (`140.82.112.4`, `185.199.108.153`, …). Applied as a DROP on INPUT, that blocks reply traffic from GitHub and breaks github.com access and release downloads intermittently.

## Root cause

Not a matching bug — the exclusion engine in `update_tables.py` is already CIDR-aware (`subnet_of` / `address_exclude`). The issue is purely configuration:

- `tables/outbound/urlexclusion_outbound` includes `github_ip_list.txt` ✅
- `tables/inbound/urlexclusion_inbound` did **not** ❌ (only the two DNS resolver lists)

So GitHub was stripped from outbound but never from inbound — exactly matching the reporter's observation that the overlap was isolated to `inbound.txt`.

## Fix

Add the GitHub feed to `urlexclusion_inbound`, mirroring how the public DNS resolver lists are already excluded in both directions. One line:

```
https://raw.githubusercontent.com/bitwire-it/Github-IP/refs/heads/main/github_ip_list.txt
```

## Verification

- Confirmed all of the issue's IPs are present in `inbound.txt` and absent from `outbound.txt` (proving the engine works where the feed is configured).
- Confirmed every leaking IP is contained by a CIDR in the feed, so the CIDR-aware exclusion will remove them once inbound reads the feed:

```
140.82.112.4    -> removed by 140.82.112.0/20
185.199.108.153 -> removed by 185.199.108.0/22
(… all 10 covered)
```

## Note

This changes the exclusion **config**; `inbound.txt` itself is regenerated by `update_tables.py`. The leaking IPs will be gone after the next run of the Update IP Lists workflow (every 2h) — or trigger it manually via `workflow_dispatch` for immediate effect.

The exclusion is intentionally scoped to GitHub's **service** endpoints; the shared Azure ranges used by Actions/Dependabot/Copilot are deliberately not in the feed, so this doesn't blind the blocklist to abuse hosted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QL6DQrpw7CCvmypecaZAyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QL6DQrpw7CCvmypecaZAyQ)_